### PR TITLE
Add dynamic image path

### DIFF
--- a/source/scss/jquery.fancybox.scss
+++ b/source/scss/jquery.fancybox.scss
@@ -1,4 +1,7 @@
 /*! fancyBox v2.1.4 fancyapps.com | fancyapps.com/fancybox/#license */
+
+$image-path: '../img/' !default;
+
 .fancybox-wrap,
 .fancybox-skin,
 .fancybox-outer,
@@ -76,7 +79,7 @@
 }
 
 #fancybox-loading, .fancybox-close, .fancybox-prev span, .fancybox-next span {
-	background-image: url('../img/fancybox_sprite.png');
+	background-image: url($image-path + 'fancybox_sprite.png');
 }
 
 #fancybox-loading {
@@ -94,7 +97,7 @@
 #fancybox-loading div {
 	width: 44px;
 	height: 44px;
-	background: url('../img/fancybox_loading.gif') center center no-repeat;
+	background: url($image-path + 'fancybox_loading.gif') center center no-repeat;
 }
 
 .fancybox-close {
@@ -114,7 +117,7 @@
 	height: 100%;
 	cursor: pointer;
 	text-decoration: none;
-	background: transparent url('../img/blank.gif'); /* helps IE */
+	background: transparent url($image-path + 'blank.gif'); /* helps IE */
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
 	z-index: 8040;
 }
@@ -175,7 +178,7 @@
 	overflow: hidden;
 	display: none;
 	z-index: 8010;
-	background: url('../img/fancybox_overlay.png');
+	background: url($image-path + 'fancybox_overlay.png');
 }
 
 .fancybox-overlay-fixed {


### PR DESCRIPTION
Fix #1 

This proposed fix will allow someone to dynamically set an $image-path variable before they @import the fancybox Sass into their own Sass files.

For example, I have a file titled **main.scss** which I use to import all of my other Sass partials, like so:

``` scss
@import 'slick.scss';
@import 'utils/variables';
@import 'utils/functions';
@import 'utils/mixins';
```

Ideally, I should be able to include the jquery.fancybox.scss file into this file, just like the others, like so (the proper path is loaded via Gulp, so this import points to the node_modules jquery-fancybox directory):

``` scss
@import 'jquery.fancybox';
```

The issue is that when I output my css file, say to /dist/main.css, the image path is relative to wherever this file is located. So, since the url is currently set up like this: url('../img/image-file.jpeg'), it will look for an img directory in the parent directory of /dist/ and obviously not find it. I want to use the /img/ directory as found in the npm package.

One solution is to create a gulp task that copies the npm package's /img/ directory into my project, but this solution requires writing another task in my build process. A better solution is the one proposed in this pull request, which is actually an idea I got from font-awesome's sass files (they allow this type of functionality for their font directory: https://github.com/FortAwesome/Font-Awesome/blob/master/scss/_variables.scss, https://github.com/FortAwesome/Font-Awesome/blob/master/scss/font-awesome.scss).

In **jquery.fancybox.scss**, include a default $image-path variable, that's used throughout the file to set the image path for the image URLs.

Then, in my **main.scss** I can do the following:

``` scss
$image-path: '../../../node_modules/jquery-fancybox/source/img/';
@import 'jquery.fancybox';
```

This will override the $image-path variable inside of jquery.fancybox.scss and allow the proper URL to resolve for my project's file structure.
